### PR TITLE
Added a preset identity provider for the MalangMalang OAuth2

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/UsernameTemplateMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/UsernameTemplateMapper.java
@@ -30,6 +30,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.social.bitbucket.BitbucketIdentityProviderFactory;
 import org.keycloak.social.facebook.FacebookIdentityProviderFactory;
+import org.keycloak.social.malang.MalangIdentityProviderFactory;
 import org.keycloak.social.github.GitHubIdentityProviderFactory;
 import org.keycloak.social.gitlab.GitLabIdentityProviderFactory;
 import org.keycloak.social.google.GoogleIdentityProviderFactory;
@@ -67,6 +68,7 @@ public class UsernameTemplateMapper extends AbstractClaimMapper {
             OIDCIdentityProviderFactory.PROVIDER_ID,
             BitbucketIdentityProviderFactory.PROVIDER_ID,
             FacebookIdentityProviderFactory.PROVIDER_ID,
+	    MalangIdentityProviderFactory.PROVIDER_ID,
             GitHubIdentityProviderFactory.PROVIDER_ID,
             GitLabIdentityProviderFactory.PROVIDER_ID,
             GoogleIdentityProviderFactory.PROVIDER_ID,

--- a/services/src/main/java/org/keycloak/social/malang/MalangIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/malang/MalangIdentityProvider.java
@@ -1,0 +1,77 @@
+package org.keycloak.social.malang;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
+import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.broker.social.SocialIdentityProvider;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.saml.common.util.StringUtil;
+
+public class MalangIdentityProvider extends AbstractOAuth2IdentityProvider<MalangIdentityProviderConfig> implements SocialIdentityProvider<MalangIdentityProviderConfig> {
+
+        public static final String AUTH_URL = "https://accounts.malangmalang.com/oauth2/authorize";
+        public static final String TOKEN_URL = "https://api.malangmalang.com/accounts/oauth2/token";
+        public static final String PROFILE_URL = "https://api.malangmalang.com/accounts/oauth2/me";
+        public static final String DEFAULT_SCOPE = "email";
+
+        protected static final String PROFILE_URL_FIELDS_SEPARATOR = ",";
+
+        public MalangIdentityProvider(KeycloakSession session, MalangIdentityProviderConfig config) {
+                super(session, config);
+                config.setAuthorizationUrl(AUTH_URL);
+                config.setTokenUrl(TOKEN_URL);
+                config.setUserInfoUrl(PROFILE_URL);
+        }
+
+        protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
+
+                try {
+                        final String fetchedFields = getConfig().getFetchedFields();
+                        final String url = StringUtil.isNotNull(fetchedFields)
+                                        ? String.join(PROFILE_URL_FIELDS_SEPARATOR, PROFILE_URL, fetchedFields)
+                                        : PROFILE_URL;
+
+                        JsonNode profile = SimpleHttp.doGet(url, session).header("Authorization", "Bearer " + accessToken).asJson();
+                        return extractIdentityFromProfile(null, profile);
+                } catch (Exception e) {
+                        throw new IdentityBrokerException("Could not obtain user profile from malang.", e);
+                }
+        }
+
+        @Override
+        protected boolean supportsExternalExchange() {
+                return true;
+        }
+
+        @Override
+        protected String getProfileEndpointForValidation(EventBuilder event) {
+                return PROFILE_URL;
+        }
+
+        @Override
+        protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
+               String identity = profile.get("identify").asText();
+               String email = profile.get("email").asText();
+               
+               BrokeredIdentityContext user = new BrokeredIdentityContext(identity);
+
+               user.setIdpConfig(getConfig());
+               user.setUsername(email);
+               user.setEmail(email);
+               user.setIdp(this);
+
+               AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());
+
+               return user;
+        }
+
+        @Override
+        protected String getDefaultScopes() {
+                return DEFAULT_SCOPE;
+        }
+}

--- a/services/src/main/java/org/keycloak/social/malang/MalangIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/malang/MalangIdentityProviderConfig.java
@@ -1,0 +1,28 @@
+package org.keycloak.social.malang;
+
+import java.util.Optional;
+
+import org.apache.commons.lang.StringUtils;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.saml.common.util.StringUtil;
+
+public class MalangIdentityProviderConfig extends OIDCIdentityProviderConfig {
+
+    public MalangIdentityProviderConfig(IdentityProviderModel model) {
+        super(model);
+    }
+
+    public MalangIdentityProviderConfig() {
+    }
+
+    public String getFetchedFields() {
+        return Optional.ofNullable(getConfig().get("fetchedFields"))
+                .map(fieldsConfig -> fieldsConfig.replaceAll("\\s+",""))
+                .orElse("");
+    }
+
+    public void setFetchedFields(final String fetchedFields) {
+        getConfig().put("fetchedFields", fetchedFields);
+    }
+}

--- a/services/src/main/java/org/keycloak/social/malang/MalangIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/malang/MalangIdentityProviderFactory.java
@@ -1,0 +1,32 @@
+package org.keycloak.social.malang;
+
+import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
+import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
+import org.keycloak.broker.social.SocialIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+
+public class MalangIdentityProviderFactory extends AbstractIdentityProviderFactory<MalangIdentityProvider> implements SocialIdentityProviderFactory<MalangIdentityProvider> {
+
+    public static final String PROVIDER_ID = "malang";
+
+    @Override
+    public String getName() {
+        return "MalangMalang";
+    }
+
+    @Override
+    public MalangIdentityProvider create(KeycloakSession session, IdentityProviderModel model) {
+        return new MalangIdentityProvider(session, new MalangIdentityProviderConfig(model));
+    }
+
+    @Override
+    public OAuth2IdentityProviderConfig createConfig() {
+        return new OAuth2IdentityProviderConfig();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/social/malang/MalangUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/social/malang/MalangUserAttributeMapper.java
@@ -1,0 +1,18 @@
+package org.keycloak.social.malang;
+
+import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
+
+public class MalangUserAttributeMapper extends AbstractJsonUserAttributeMapper {
+
+        private static final String[] cp = new String[] { MalangIdentityProviderFactory.PROVIDER_ID };
+
+        @Override
+        public String[] getCompatibleProviders() {
+                return cp;
+        }
+
+        @Override
+        public String getId() {
+                return "malang-user-attribute-mapper";
+        }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -28,6 +28,7 @@ org.keycloak.broker.saml.mappers.AttributeToRoleMapper
 org.keycloak.broker.saml.mappers.UserAttributeMapper
 org.keycloak.broker.saml.mappers.UsernameTemplateMapper
 org.keycloak.social.facebook.FacebookUserAttributeMapper
+org.keycloak.social.malang.MalangUserAttributeMapper
 org.keycloak.social.github.GitHubUserAttributeMapper
 org.keycloak.social.paypal.PayPalUserAttributeMapper
 org.keycloak.social.google.GoogleUserAttributeMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.social.SocialIdentityProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.social.SocialIdentityProviderFactory
@@ -16,6 +16,7 @@
 #
 
 org.keycloak.social.facebook.FacebookIdentityProviderFactory
+org.keycloak.social.malang.MalangIdentityProviderFactory
 org.keycloak.social.paypal.PayPalIdentityProviderFactory
 org.keycloak.social.github.GitHubIdentityProviderFactory
 org.keycloak.social.google.GoogleIdentityProviderFactory

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-malang-ext.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-malang-ext.html
@@ -1,0 +1,8 @@
+<div class="form-group">
+    <label class="col-md-2 control-label" for="fetchedFields">{{:: 'identity-provider.malang-fetchedFields.label' | translate}}</label>
+    <div class="col-md-6">
+        <input ng-model="identityProvider.config.fetchedFields" id="fetchedFields" class="form-control" />
+    </div>
+    <kc-tooltip>{{:: 'identity-provider.malang-fetchedFields.tooltip' | translate}}</kc-tooltip>
+</div>
+

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-malang.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-malang.html
@@ -1,0 +1,1 @@
+<div data-ng-include data-src="resourceUrl + '/partials/realm-identity-provider-social.html'"></div>


### PR DESCRIPTION
Keycloak  Identity provider 메뉴에서 말랑말랑 OAuth2 인증을 제공할 수 있도록 수정

@hnc-jglee 
@hnc-yjyoon
@hnc-hjchoe 
@hnc-jihoon
@hnc-hskim
@hnc-daehyeonkim
@hnc-lcy9104
@hnc-dongminkim 